### PR TITLE
ASD Update At-scale-debug version to 1.6.0

### DIFF
--- a/include/asd_common.h
+++ b/include/asd_common.h
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Two simple rules for the version string are:
 // 1. less than 255 in length (or it will be truncated in the plugin)
 // 2. no dashes, as they are used later up the sw stack between components.
-static char asd_version[] = "ASD_BMC_v1.5.4";
+static char asd_version[] = "ASD_BMC_v1.6.0";
 
 #define TO_ENUM(ENUM) ENUM,
 #define TO_STRING(STRING) #STRING,
@@ -126,6 +126,7 @@ typedef enum
 #define SUPPORTED_REMOTE_PROBES_CMD 16
 #define REMOTE_PROBES_CONFIG_CMD 17
 #define LOOPBACK_CMD 18
+#define REMOTE_SPP_CONFIG_CMD 19
 
 // AGENT_CONFIGURATION_CMD types
 #define AGENT_CONFIG_TYPE_LOGGING 1
@@ -361,21 +362,25 @@ typedef struct asd_i2c_msg
 #define SPP_CFG_MAX 0x0F
 
 #define SPP_CFG_BUS_SELECT 0x00
+#define MAX_SPP_BUS_DEVICES 8
 
 
-//  SPPSend         00010000
+//  SPPSend         00010000        SPP_SEND ID code
+//                  aaaaaaaa        BPK device address id (multisocket)
 //                  nnnnnnnn        n is MSB of packet size in bytes
 //                  nnnnnnnn        LSB of n is included in the next byte
 #define SPP_SEND    0x10
-#define SPP_SEND_COMMAND_SIZE 3
+#define SPP_SEND_COMMAND_SIZE 4
 
-//  SPPReceive      00100000        n is MSB of packet size in bytes
+//  SPPReceive      00100000        SPP_RECEIVE ID code
+//                  aaaaaaaa        BPK device address id (multisocket)
 //                  nnnnnnnn        n is MSB of packet size in bytes
 //                  nnnnnnnn        LSB of n is included in the next byte
 #define SPP_RECEIVE 0x20
-#define SPP_RECEIVE_COMMAND_SIZE 3
+#define SPP_RECEIVE_COMMAND_SIZE 4
 
-//  SPPSendCommand  00110000
+//  SPPSendCommand  00110000        SPP_SEND_COMMAND ID code
+//                  aaaaaaaa        BPK device address id (multisocket)
 //                  nnnnnnnn        n is MSB of packet size in bytes
 //                  nnnnnnnn        LSB of n is included in the next byte
 //                  cccccccc        c is Command type:
@@ -385,9 +390,10 @@ typedef struct asd_i2c_msg
 //                                      DebugAction             = 0xD8,
 //                                      BroadcastDebugAction    = 0x58
 #define SPP_SEND_CMD 0x30
-#define SPP_SEND_CMD_COMMAND_SIZE 4
+#define SPP_SEND_CMD_COMMAND_SIZE 5
 
-//  SPPSendRcvCmd   01000000
+//  SPPSendRcvCmd   01000000        SPP_SEND_RECEIVE_COMMAND ID code
+//                  aaaaaaaa        BPK device address id (multisocket)
 //                  nnnnnnnn        n is MSB of packet size in bytes
 //                  nnnnnnnn        LSB of n is included in the next byte
 //                  cccccccc        c is Command type:
@@ -398,7 +404,7 @@ typedef struct asd_i2c_msg
 //                  mmmmmmmm        m is MSB of read packet size in bytes
 //                  mmmmmmmm        LSB of m is included in the next byte
 #define SPP_SEND_RECEIVE_CMD 0x40
-#define SPP_SEND_RECEIVE_CMD_COMMAND_SIZE 6
+#define SPP_SEND_RECEIVE_CMD_COMMAND_SIZE 7
 
 //  SPPSetSimCmd    01010000
 //                  nnnnnnnn        n is MSB of packet size in bytes

--- a/jtag_test/jtag_test.c
+++ b/jtag_test/jtag_test.c
@@ -63,6 +63,7 @@ uint64_t failures = 0;
 const ir_shift_size_map ir_map[] = {{0x0E7BB013, IR14_SHIFT_SIZE},
                                     {0x00044113, IR16_SHIFT_SIZE},
                                     {0x00111113, IR16_SHIFT_SIZE},
+                                    {0x00133113, IR16_SHIFT_SIZE},
                                     {0x0E7C5013, IR14_SHIFT_SIZE},
                                     {0x00155113, IR16_SHIFT_SIZE},
                                     {0x00128113, IR12_SHIFT_SIZE},
@@ -71,7 +72,7 @@ const ir_shift_size_map ir_map[] = {{0x0E7BB013, IR14_SHIFT_SIZE},
                                     {0x0E7D4113, IR08_SHIFT_SIZE},
                                     {0x0012d113, IR16_SHIFT_SIZE}};
 
-#define MAP_LINE_SIZE 55
+#define MAP_LINE_SIZE 58
 char ir_size_map_str[((sizeof(ir_map)/sizeof(ir_shift_size_map)) + 6) * MAP_LINE_SIZE];
 
 #ifndef UNIT_TEST_MAIN
@@ -328,30 +329,30 @@ void load_ir_size_map_str()
 {
     int arr_size = sizeof(ir_map)/sizeof(ir_shift_size_map);
     sprintf_s(&ir_size_map_str[0], MAP_LINE_SIZE,
-              "                             +------------+---------+\n");
+              "                             +------------+------------+\n");
     sprintf_s(&ir_size_map_str[MAP_LINE_SIZE - 1], MAP_LINE_SIZE,
-              "                             |  ID CODE   | IR-SIZE |\n");
+              "                             |  ID CODE   |IR-SIZE(HEX)|\n");
     sprintf_s(&ir_size_map_str[(MAP_LINE_SIZE - 1) * 2], MAP_LINE_SIZE,
-              "                             +------------+---------+\n");
+              "                             +------------+------------+\n");
 
     for (int i=0; i<arr_size; i++) {
         sprintf_s(&ir_size_map_str[(MAP_LINE_SIZE - 1)*(3 + i)], MAP_LINE_SIZE,
-                  "                             | 0x%08x | %d%s   |\n",
+                  "                             | 0x%08x | 0x%x%s    |\n",
                   ir_map[i].signature,
                   ir_map[i].ir_shift_size,
-                  ir_map[i].ir_shift_size < 10 ? "    ":
-                  ir_map[i].ir_shift_size < 100 ? "   ":
-                  ir_map[i].ir_shift_size < 1000 ? "  ": " ");
+                  ir_map[i].ir_shift_size < 0x10 ? "    ":
+                  ir_map[i].ir_shift_size < 0x100 ? "   ":
+                  ir_map[i].ir_shift_size < 0x1000 ? "  ": " ");
     }
     sprintf_s(&ir_size_map_str[(MAP_LINE_SIZE-1) * (arr_size+3)], MAP_LINE_SIZE,
-              "                             | DEFAULT    | %d%s   |\n",
+              "                             | DEFAULT    | 0x%x%s    |\n",
               DEFAULT_IR_SHIFT_SIZE,
-              DEFAULT_IR_SHIFT_SIZE < 10 ? "    ":
-              DEFAULT_IR_SHIFT_SIZE < 100 ? "   ":
-              DEFAULT_IR_SHIFT_SIZE < 1000 ? "  ": " ");
+              DEFAULT_IR_SHIFT_SIZE < 0x10 ? "    ":
+              DEFAULT_IR_SHIFT_SIZE < 0x100 ? "   ":
+              DEFAULT_IR_SHIFT_SIZE < 0x1000 ? "  ": " ");
 
     sprintf_s(&ir_size_map_str[(MAP_LINE_SIZE-1) * (arr_size+4)], MAP_LINE_SIZE,
-              "                             +------------+---------+\n");
+              "                             +------------+------------+\n");
 
 }
 

--- a/server/asd_main.c
+++ b/server/asd_main.c
@@ -444,6 +444,7 @@ void showUsage(char** argv)
 {
     ASD_log(
         ASD_LogLevel_Error, ASD_LogStream_Daemon, ASD_LogOption_No_Remote,
+        "\nVersion: %s"
         "\nUsage: %s [option]\n\n"
         "  -p <number> Port number (default=%d)\n\n"
         "  -s          Route log messages to the system log\n"
@@ -502,7 +503,7 @@ void showUsage(char** argv)
         "Default logging, only listen on eth0.\n"
         "     asd -n eth0\n"
         "\n",
-        argv[0], DEFAULT_PORT, DEFAULT_CERT_FILE,
+        asd_version, argv[0], DEFAULT_PORT, DEFAULT_CERT_FILE,
         MAX_IxC_BUSES, MAX_IxC_BUSES,
         ASD_LogLevelString[DEFAULT_LOG_LEVEL],
         ASD_LogLevelString[ASD_LogLevel_Off],

--- a/server/asd_target_interface.c
+++ b/server/asd_target_interface.c
@@ -111,7 +111,7 @@ STATUS asd_api_target_ioctl(void* input, void* output, unsigned int cmd)
                 break;
             target_interface_version = (char *) output;
             status = asd_target_interface_version(target_interface_version);
-        break;
+            break;
         case IOCTL_TARGET_IS_INTERFACE_SUPPORTED:
             if (input == NULL || output == NULL)
                 break;
@@ -119,6 +119,7 @@ STATUS asd_api_target_ioctl(void* input, void* output, unsigned int cmd)
             bool * supported = (bool *) output;
             *supported = asd_is_api_target_version_supported(target_interface_version);
             status = ST_OK;
+            break;
         default:
             status = asd_target_ioctl(input, output, cmd);
     }

--- a/spp_test/CMakeLists.txt
+++ b/spp_test/CMakeLists.txt
@@ -20,3 +20,5 @@ if(NOT ${BUILD_UT})
     install (TARGETS spp_test DESTINATION bin)
 endif(NOT ${BUILD_UT})
 
+add_subdirectory(debug_over_i3c)
+

--- a/spp_test/debug_over_i3c/CMakeLists.txt
+++ b/spp_test/debug_over_i3c/CMakeLists.txt
@@ -1,0 +1,29 @@
+project (debug-over-i3c C CXX)
+
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+
+add_executable (debug-over-i3c debug-over-i3c.c)
+
+set (
+        CMAKE_C_FLAGS
+        "${CMAKE_C_FLAGS} \
+    -Wall \
+    -Wextra \
+    -Wunused \
+    -Wsign-conversion \
+    -Wnull-dereference \
+    -Wdouble-promotion \
+    -Wformat=2 \
+    -Wno-unused-parameter \
+    -Werror \
+    -Wduplicated-cond \
+    -Wduplicated-branches \
+    -Wlogical-op \
+    -Wshadow \
+    -Wmisleading-indentation \
+"
+)
+
+install (TARGETS debug-over-i3c DESTINATION bin)

--- a/spp_test/debug_over_i3c/debug-over-i3c.c
+++ b/spp_test/debug_over_i3c/debug-over-i3c.c
@@ -1,0 +1,376 @@
+/*
+Copyright (c) 2024, Intel Corporation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "debug-over-i3c.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <poll.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 0
+
+#define FRAME_TOTAL_LIMIT 512
+
+enum verbose_level
+{
+    verbose_error = 0,
+    verbose_warn = 1,
+    verbose_info = 2,
+    verbose_debug = 3,
+};
+
+const char *sopts = "d:r:w:o:a:nexvh";
+static const struct option lopts[] = {
+    {"device",  required_argument,  NULL,   'd' },
+    {"read",    required_argument,  NULL,   'r' },
+    {"write",   required_argument,  NULL,   'w' },
+    {"opcode",  required_argument,  NULL,   'o' },
+    {"action",  required_argument,  NULL,   'a' },
+    {"nopoll",  no_argument,        NULL,   'n' },
+    {"event",   no_argument,        NULL,   'e' },
+    {"verbose", no_argument,        NULL,   'x' },
+    {"version", no_argument,        NULL,   'v' },
+    {"help",    no_argument,        NULL,   'h' },
+    {0, 0, 0, 0}
+};
+
+enum verbose_level verbose_level;
+#define trace(level, ...)       \
+{                               \
+    if (level <= verbose_level) \
+    {                           \
+        printf(__VA_ARGS__);    \
+    }                           \
+}                               \
+
+static void print_help()
+{
+    printf("This tools can be used to write or/and read data over I3C DBG binding to check Debug for I3C feature.\n");
+    printf("\n");
+    printf("Options:\n");
+    printf("   --device (-d): path to the debug for I3C handle, e.g. /dev/i3c-debug-0\n");
+    printf("   --read (-r): number of byte to read, maximal possible value shall be provided to be sure whole received message is read\n");
+    printf("   --write (-w): list of byte to write\n");
+    printf("   --opcode (-o): opcode value for Debug Opcode CCC, could be used along with -w and/or -r if additional data shall be write and/or read\n");
+    printf("   --action (-a): action value for Debug Action CCC\n");
+    printf("   --nopoll (-n): do not run poll() while reading data\n");
+    printf("   --event (-e): run get event ioctl and print data if any\n");
+    printf("   --verbose (-x): verbosity level, more 'x' - more verbose\n");
+    printf("   --version (-v): print tool version\n");
+    printf("   --help (-h): print this help\n");
+    printf("\n");
+    printf("Usage examples:\n");
+    printf("   write request: ./debug-over-i3c -d /dev/i3c-debug-0 -w 0x22,0x30,0x00,0x00,0x11,0xEE,0x77,0x88,0xA5,0xC3,0xC3,0xA5\n");
+    printf("   write request and read response: ./debug-over-i3c -d /dev/i3c-debug-0 -w 0x22,0x30,0x00,0x00,0x11,0xEE,0x77,0x88,0xA5,0xC3,0xC3,0xA5 -r 255\n");
+    printf("   send Debug Opcode CCC and read response: ./debug-over-i3c -d /dev/i3c-debug-0 -o 0x00 -r 4\n");
+    printf("   send Debug Opcode CCC with extra data: ./debug-over-i3c -d /dev/i3c-debug-0 -o 0x02 -w 0x00\n");
+    printf("   send Debug Action CCC: ./debug-over-i3c -d /dev/i3c-debug-0 -a 0xFD\n");
+}
+
+static void print_version()
+{
+    printf("Debug over I3C Utility. Version %i.%i\n", VERSION_MAJOR, VERSION_MINOR);
+}
+
+char data_str_buffer[2048];
+static bool get_write_data(const char * const  optarg, uint8_t data[], size_t *len)
+{
+    size_t input_str_len = strlen(optarg);
+    char *byte_str;
+    size_t index = 0;
+
+    if (input_str_len >= sizeof(data_str_buffer))
+    {
+        input_str_len = sizeof(data_str_buffer) - 1;
+    }
+    memcpy(data_str_buffer, optarg, input_str_len);
+    data_str_buffer[input_str_len] = 0;
+
+    byte_str = strtok(data_str_buffer, ",");
+    while(byte_str != NULL)
+    {
+        data[index++] = (uint8_t)strtol(byte_str, NULL, 0);
+        byte_str = strtok(NULL, ",");
+    }
+
+    if (index > 0)
+    {
+        *len = index;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    uint8_t write_buffer[FRAME_TOTAL_LIMIT] = {0};
+    uint8_t read_buffer[FRAME_TOTAL_LIMIT] = {0};
+    uint8_t event_buffer[FRAME_TOTAL_LIMIT] = {0};
+    bool do_read = false, do_write = false, do_event = false;
+    struct pollfd debug_poll_fd;
+    char* device_path = NULL;
+    size_t read_len = 0;
+    size_t write_len = 0;
+    int debug_fd = -1;
+    int opcode = -1;
+    int action = -1;
+    bool nopoll = false;
+    int opt;
+    int ret;
+    size_t i;
+
+    while ((opt = getopt_long(argc, argv, sopts, lopts, NULL)) != EOF)
+    {
+        switch (opt)
+        {
+            case 'h':
+                print_help();
+                return 0;
+            case 'v':
+                print_version();
+                return 0;
+            case 'd':
+                device_path = optarg;
+                break;
+            case 'r':
+                read_len = (size_t)strtol(optarg, NULL, 0);
+                if (read_len > 0)
+                {
+                    do_read = true;
+                }
+                break;
+            case 'w':
+                do_write = get_write_data(optarg, write_buffer, &write_len);
+                break;
+            case 'x':
+                verbose_level++;
+                break;
+            case 'o':
+                opcode = (int)strtol(optarg, NULL, 0);
+                break;
+            case 'a':
+                action = (int)strtol(optarg, NULL, 0);
+                break;
+            case 'n':
+                nopoll = true;
+                break;
+            case 'e':
+                do_event = true;
+                break;
+            default:
+                print_help();
+                return -1;
+        }
+    }
+
+    if (do_read || do_write || opcode >= 0 || action >= 0 || do_event)
+    {
+        if (!device_path)
+        {
+            trace(verbose_error, "Device path not provided!\n");
+            print_help();
+            return -1;
+        }
+    }
+
+    if (read_len > sizeof(read_buffer) || write_len > sizeof(write_buffer))
+    {
+        trace(verbose_error,
+              "Invalid read or write length - larger than internal buffer size (%d bytes)\n",
+              FRAME_TOTAL_LIMIT);
+        return -1;
+    }
+
+    debug_fd = open(device_path, O_RDWR);
+    if (debug_fd < 0)
+    {
+        trace(verbose_error, "Failed to open device path: %s, errno=%i\n",
+              device_path, errno);
+        return debug_fd;
+    }
+
+    if (opcode >= 0)
+    {
+        struct i3c_debug_opcode_ccc ocpode_ccc = {0};
+
+        ocpode_ccc.opcode = opcode;
+        if (write_len)
+        {
+            ocpode_ccc.write_len = write_len;
+            ocpode_ccc.write_ptr = (uintptr_t)write_buffer;
+        }
+        if (read_len)
+        {
+            ocpode_ccc.read_len = read_len;
+            ocpode_ccc.read_ptr = (uintptr_t)read_buffer;
+        }
+
+        ret = ioctl(debug_fd, I3C_DEBUG_IOCTL_DEBUG_OPCODE_CCC,
+                    (int32_t*)&ocpode_ccc);
+        trace(verbose_info, "Ioctl debug opcode status: %i, errno=%i\n", ret,
+              errno);
+        if (ret < 0)
+        {
+            trace(verbose_error, "Failed to send Debug Opcode ioctl\n");
+        }
+        else
+        {
+            if (read_len > 0)
+            {
+                printf("Data: ");
+                for (i = 0; i < read_len; ++i)
+                {
+                    printf(" %02X", read_buffer[i]);
+                }
+                printf("\n");
+            }
+        }
+        return ret;
+    }
+
+    if (action >= 0)
+    {
+        struct i3c_debug_action_ccc action_ccc;
+
+        action_ccc.action = action;
+
+        ret = ioctl(debug_fd, I3C_DEBUG_IOCTL_DEBUG_ACTION_CCC,
+                    (int32_t*)&action_ccc);
+        trace(verbose_info, "Ioctl debug action status: %i, errno=%i\n", ret,
+              errno);
+        if (ret < 0)
+        {
+            trace(verbose_error, "Failed to send Debug Action ioctl\n");
+        }
+        return ret;
+    }
+
+    if (do_write)
+    {
+        ssize_t write_ret;
+
+        trace(verbose_info, "Writing data..., write length = %zu\n", write_len);
+        write_ret = write(debug_fd, write_buffer, write_len);
+        trace(verbose_info, "Write status: %zi, errno=%i\n", write_ret, errno);
+        if (write_ret < 0)
+        {
+            trace(verbose_error, "Failed to write data\n");
+        }
+    }
+
+    if (do_event)
+    {
+        struct i3c_get_event_data event_data;
+
+        debug_poll_fd.fd = debug_fd;
+        debug_poll_fd.events = POLLIN;
+
+        if (!nopoll)
+        {
+            trace(verbose_info, "Starting poll\n");
+        }
+
+        for (;;)
+        {
+            if (!nopoll)
+            {
+                ret = poll(&debug_poll_fd, 1, 1000);
+                if (ret < 0)
+                {
+                    trace(verbose_error, "Error while polling\n");
+                    return ret;
+                }
+            }
+
+            if (nopoll || ((debug_poll_fd.revents & POLLIN) == POLLIN))
+            {
+                event_data.data_len = (uint16_t)(sizeof(event_buffer));
+                event_data.data_ptr = (uintptr_t)event_buffer;
+                ret = ioctl(debug_fd, I3C_DEBUG_IOCTL_GET_EVENT_DATA,
+                            (int32_t*)&event_data);
+                trace(verbose_info,
+                      "Ioctl get event data status: %i, errno=%i\n", ret,
+                      errno);
+                if (ret < 0)
+                {
+                    trace(verbose_error,
+                          "Failed to send Get Event Data ioctl\n");
+                }
+                else
+                {
+                    trace(verbose_info, "Event data length = %d",
+                          event_data.data_len);
+                    printf(", data:");
+                    for (i = 0; i < (size_t)event_data.data_len; ++i)
+                    {
+                        printf(" %02X", event_buffer[i]);
+                    }
+                    printf("\n");
+                }
+                break;
+            }
+        }
+    }
+
+    if (do_read)
+    {
+        ssize_t read_ret;
+
+        trace(verbose_info, "Reading data...\n");
+
+        memset(read_buffer, 0, sizeof(read_buffer));
+        read_ret = read(debug_fd, read_buffer, read_len);
+        trace(verbose_info, "Read status: %zi, errno=%i\n", read_ret, errno);
+        if (read_ret < 0)
+        {
+            trace(verbose_error, "Failed to read data, read_ret=%zd\n",
+                  read_ret);
+            return (int)read_ret;
+        }
+
+        printf("Data: ");
+        for (i = 0; i < (size_t)read_ret; ++i)
+        {
+            printf(" %02X", read_buffer[i]);
+        }
+        printf("\n");
+    }
+
+    return 0;
+}

--- a/spp_test/debug_over_i3c/debug-over-i3c.h
+++ b/spp_test/debug_over_i3c/debug-over-i3c.h
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2024, Intel Corporation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef AT_SCALE_DEBUG_DEBUG_OVER_I3C_H
+#define AT_SCALE_DEBUG_DEBUG_OVER_I3C_H
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcpp"
+#include <linux/ioctl.h>
+#include <linux/types.h>
+#pragma GCC diagnostic pop
+
+
+
+struct i3c_debug_opcode_ccc {
+    __u8 opcode;
+    __u16 write_len;
+    __u64 write_ptr;
+    __u16 read_len;
+    __u64 read_ptr;
+};
+
+struct i3c_debug_action_ccc {
+    __u8 action;
+};
+
+struct i3c_get_event_data {
+    __u16 data_len;
+    __u64 data_ptr;
+};
+
+#define I3C_DEBUG_IOCTL_BASE    0x79
+
+#define I3C_DEBUG_IOCTL_DEBUG_OPCODE_CCC \
+	_IOWR(I3C_DEBUG_IOCTL_BASE, 0x41, struct i3c_debug_opcode_ccc)
+
+#define I3C_DEBUG_IOCTL_DEBUG_ACTION_CCC \
+	_IOW(I3C_DEBUG_IOCTL_BASE, 0x42, struct i3c_debug_action_ccc)
+
+#define I3C_DEBUG_IOCTL_GET_EVENT_DATA \
+	_IOWR(I3C_DEBUG_IOCTL_BASE, 0x43, struct i3c_get_event_data)
+#endif // AT_SCALE_DEBUG_DEBUG_OVER_I3C_H

--- a/spp_test/spp_test.h
+++ b/spp_test/spp_test.h
@@ -88,10 +88,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SP_AS_EN_STAT 0xc0
 #define SP_AS_EN_SET 0xc8
 #define SP_AS_AVAIL_STAT 0xd0
+#define SP_AS_EN_CLEAR 0xcc
 #define SP_AS_AVAIL_REQ_SET 0xd8
 #define SP_SESSION_MGMT_0 0x180
 #define SP_SESSION_MGMT_1 0x184
 #define JTAG_SET 0x1
+#define CLEAR_ALL 0xFFFFFFFF
 
 
 struct jtagSppCommandPacket {
@@ -200,7 +202,7 @@ typedef struct spp_test_args
     bool manual_mode;
     bool count_mode;
     bool random_mode;
-    bus_options busopt;
+    bus_config buscfg;
     unsigned char tap_data_pattern[12]; // Used for tap data comparison
     ASD_LogLevel log_level;
     ASD_LogStream log_streams;
@@ -262,6 +264,7 @@ void interrupt_handler(int dummy);
 STATUS parse_arguments(int argc, char** argv, spp_test_args* args);
 void showUsage(char** argv);
 STATUS initialize_bpk(SPP_Handler* state);
+STATUS disconnect_bpk(SPP_Handler* state);
 STATUS configure_bpk(SPP_Handler* state, spp_test_args* args);
 unsigned int find_pattern(const unsigned char* haystack,
                           unsigned int haystack_size,

--- a/target/i3c_debug_handler.h
+++ b/target/i3c_debug_handler.h
@@ -52,7 +52,7 @@ struct i3c_debug_opcode_ccc {
 struct i3c_debug_action_ccc {
     __u8 action;
 };
-#define TIMEOUT_I3C_DEBUG_RX 1000   // milliseconds
+#define TIMEOUT_I3C_DEBUG_RX  300   // milliseconds
 
 #define I3C_DEBUG_IOCTL_BASE    0x79
 
@@ -84,8 +84,8 @@ typedef struct i3c_cmd
     enum i3cMsgType msgType;
     uint8_t opcode;
     uint8_t action;
-    uint16_t write_len;
-    uint16_t read_len;
+    int16_t write_len;
+    int16_t read_len;
     uint8_t* tx_buffer;
     uint8_t* rx_buffer;
 } i3c_cmd;
@@ -95,10 +95,10 @@ STATUS init_i3c( SPP_Handler* state);
 STATUS send_i3c_action(SPP_Handler* state, i3c_cmd *cmd);
 STATUS send_i3c_opcode(SPP_Handler* state, i3c_cmd *cmd);
 ssize_t receive_i3c(SPP_Handler* state, i3c_cmd *cmd);
-void debug_rx(i3c_cmd* cmd);
-void debug_i3c_tx(i3c_cmd* cmd);
+void debug_i3c_rx(i3c_cmd*, int device_index);
+void debug_i3c_tx(i3c_cmd* cmd, int device_index);
 STATUS send_i3c_cmd(SPP_Handler* state, i3c_cmd *cmd);
-STATUS i3c_ibi_handler(int fd, uint8_t* ibi_buffer, uint16_t* ibi_len);
+STATUS i3c_ibi_handler(int fd, uint8_t* ibi_buffer, size_t* ibi_len);
 
 
 #endif // I3C_DEBUG_HANDLER_H

--- a/target/spp_handler.h
+++ b/target/spp_handler.h
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 
 #define UNINITIALIZED_SPP_DEBUG_DRIVER_HANDLE -1
-
+#define SPASENCLEAR_CMD {0x52, 0x30, 0x04, 0x00, 0xcc, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff}
 typedef uint16_t __u16;
 typedef uint8_t __u8;
 typedef uint32_t __u32;
@@ -54,6 +54,9 @@ typedef struct SPP_Handler
     uint8_t spp_bus;
     int spp_buses[MAX_SPP_BUSES];
     bus_config* config;
+    int spp_dev_handlers[MAX_SPP_BUS_DEVICES];
+    int spp_device_count;
+    uint8_t device_index;
     int spp_driver_handle;
     bool ibi_handled;
 } SPP_Handler;
@@ -61,9 +64,13 @@ typedef struct SPP_Handler
 SPP_Handler* SPPHandler(bus_config* config);
 STATUS spp_initialize(SPP_Handler* state);
 STATUS spp_deinitialize(SPP_Handler* state);
+STATUS disconnect(SPP_Handler* state);
 STATUS spp_bus_flock(SPP_Handler* state, uint8_t bus, int op);
 STATUS spp_bus_select(SPP_Handler* state, uint8_t bus);
 STATUS spp_set_sclk(SPP_Handler* state, uint16_t sclk);
+STATUS spp_bus_device_count(SPP_Handler* state, uint8_t * count);
+STATUS spp_bus_get_device_map(SPP_Handler* state, uint32_t * device_mask);
+STATUS spp_device_select(SPP_Handler* state, uint8_t device);
 STATUS spp_send(SPP_Handler* state, uint16_t size, uint8_t * write_buffer);
 STATUS spp_receive(SPP_Handler* state, uint16_t * size, uint8_t * read_buffer);
 STATUS spp_send_cmd(SPP_Handler* state, spp_command_t cmd, uint16_t size, 

--- a/target/target_handler.h
+++ b/target/target_handler.h
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "asd_common.h"
 #include "dbus_helper.h"
 #include "gpio.h"
+#include "spp_handler.h"
 
 #define POLL_GPIO (POLLPRI + POLLERR)
 #define CHIP_BUFFER_SIZE 32
@@ -159,6 +160,14 @@ typedef struct Target_Control_GPIO
     Pin_Type type;
 } Target_Control_GPIO;
 
+typedef struct ASD_EVENT_DATA
+{
+    uint32_t addr;
+    size_t size;
+    char* buffer;
+} ASD_EVENT_DATA;
+
+
 typedef struct Target_Control_Handle
 {
     event_configuration event_cfg;
@@ -168,9 +177,7 @@ typedef struct Target_Control_Handle
     bool is_controller_probe;
     bool xdp_present;
     int spp_fd;
-    bool i3c_ibi_handled;
-    char* ibi_event_buffer;
-    size_t ibi_event_size;
+    SPP_Handler* spp_handler;
 } Target_Control_Handle;
 
 typedef struct data_json_map
@@ -195,7 +202,7 @@ STATUS target_wait_PRDY(Target_Control_Handle* state, uint8_t log2time);
 STATUS target_get_fds(Target_Control_Handle* state, target_fdarr_t* fds,
                       int* num_fds);
 STATUS target_event(Target_Control_Handle* state, struct pollfd poll_fd,
-                    ASD_EVENT* event);
+                    ASD_EVENT* event, ASD_EVENT_DATA * ret_data);
 STATUS target_wait_sync(Target_Control_Handle* state, uint16_t timeout,
                         uint16_t delay);
 STATUS on_power_event(Target_Control_Handle* state, ASD_EVENT* event);


### PR DESCRIPTION
Important Notice:
Please note that if the ASD application base code is updated to version 1.5.4 or later, it is mandatory to also update the JTAG driver code to match the version in the OpenBMC Linux kernel dev-6.1. We have recently introduced a new functionality in the JTAG driver to support the RunTCK command. To accommodate this new feature, the ASD application has undergone compatibility changes. These changes are not backward compatible with previous versions of the JTAG driver and may cause the ASD to fail with a "failed to initialize JTAG driver" symptom.

Tested:
Confirm ASD version reported at connection is 1.6.0