### PR TITLE
ASD Update At-scale-debug version to 1.6.2

### DIFF
--- a/include/asd_common.h
+++ b/include/asd_common.h
@@ -44,10 +44,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MAX_WAIT_CYCLES 256
 #define BROADCAST_MESSAGE_ORIGIN_ID 7
 #define MAX_FIELD_NAME_SIZE 40
+#define IDLE_TIMEOUT_MS 600000
 // Two simple rules for the version string are:
 // 1. less than 255 in length (or it will be truncated in the plugin)
 // 2. no dashes, as they are used later up the sw stack between components.
-static char asd_version[] = "ASD_BMC_v1.6.0";
+static char asd_version[] = "ASD_BMC_v1.6.2";
 
 #define TO_ENUM(ENUM) ENUM,
 #define TO_STRING(STRING) #STRING,
@@ -71,6 +72,13 @@ typedef enum
     ASD_EVENT_BPK,
     ASD_EVENT_NONE
 } ASD_EVENT;
+
+typedef struct ASD_EVENT_DATA
+{
+    uint32_t addr;
+    size_t size;
+    char* buffer;
+} ASD_EVENT_DATA;
 
 typedef enum
 {
@@ -250,6 +258,12 @@ typedef struct bus_options
     bus_config_type bus_config_type[MAX_IxC_BUSES + MAX_SPP_BUSES];
     uint8_t bus;
 } bus_options;
+
+typedef struct timeout_config // stack memory
+{
+    bool is_timeout_enabled;
+    long idle_timeout;
+}timeout_config;
 
 //  At Scale Debug Commands
 //

--- a/include/config.h
+++ b/include/config.h
@@ -60,8 +60,9 @@ typedef struct config
     remote_logging_config remote_logging;
     IPC_LogType ipc_asd_log_map[6];
     bus_config buscfg;
+    timeout_config timecfg;
 } config;
 
-STATUS set_config_defaults(config* config, const bus_options* opt);
+STATUS set_config_defaults(config* config, const bus_options* opt, const timeout_config* tmo_cfg);
 
 #endif // __CONFIG_H_

--- a/include/logging.h
+++ b/include/logging.h
@@ -32,6 +32,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 
 #define ENABLE_DEBUG_LOGGING
+#define LOG_TIMESTAMP_LENGTH 17
+#define LOG_MESSAGE_LENGTH 4096
+#define LOG_TIME_MESSAGE_LENGTH (LOG_MESSAGE_LENGTH + LOG_TIMESTAMP_LENGTH)
+#define LOG_TIME_LINE_LENGTH 180
 #define CALLBACK_LOG_MESSAGE_LENGTH 256
 
 typedef enum
@@ -87,6 +91,7 @@ void ASD_log_shift(ASD_LogLevel level, ASD_LogStream stream,
 
 void ASD_initialize_log_settings(ASD_LogLevel level, ASD_LogStream stream,
                                  bool write_to_syslog,
+                                 bool log_timestamp_enable,
                                  ShouldLogFunctionPtr should_log_ptr,
                                  LogFunctionPtr log_ptr);
 
@@ -119,5 +124,7 @@ static inline char* streamtostring(ASD_LogStream stream)
         return "All";
     return "Unknown-Stream";
 }
+
+bool ASD_get_timestamp(char* time_buffer);
 
 #endif // _LOGGING_H_

--- a/jtag_test/jtag_test.h
+++ b/jtag_test/jtag_test.h
@@ -112,7 +112,8 @@ JTAG_Handler* init_jtag(jtag_test_args* args);
 
 unsigned int find_pattern(const unsigned char* haystack,
                           unsigned int haystack_size,
-                          const unsigned char* needle);
+                          const unsigned char* needle,
+                          unsigned int needle_size);
 
 bool reset_jtag_to_RTI(JTAG_Handler* jtag);
 

--- a/jtag_test/tests/jtag_test_tests.c
+++ b/jtag_test/tests/jtag_test_tests.c
@@ -258,7 +258,8 @@ static void find_pattern_not_found_returns_0(void** state)
     unsigned char dead_beef[8];
     memcpy(dead_beef, &human_readable, sizeof(human_readable));
     memset(shiftDataOut, 0xff, sizeof(shiftDataOut));
-    assert_int_equal(find_pattern(shiftDataOut, shiftSize, dead_beef), 0);
+    assert_int_equal(find_pattern(shiftDataOut, shiftSize,
+                     dead_beef, sizeof(dead_beef)), 0);
 }
 
 static void find_pattern_found_returns_value(void** state)
@@ -271,7 +272,8 @@ static void find_pattern_found_returns_value(void** state)
     memcpy(dead_beef, &human_readable, sizeof(human_readable));
     memset(shiftDataOut, 0xff, sizeof(shiftDataOut));
     memcpy(shiftDataOut + expected, &human_readable, sizeof(human_readable));
-    assert_int_equal(find_pattern(shiftDataOut, shiftSize, dead_beef),
+    assert_int_equal(find_pattern(shiftDataOut, shiftSize,
+                     dead_beef, sizeof(dead_beef)),
                      expected);
 }
 

--- a/server/asd_main.h
+++ b/server/asd_main.h
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ext_network.h"
 #include "logging.h"
 #include "session.h"
+#include "sys/time.h"
 
 // DEFAULTS
 #define DEFAULT_I2C_ENABLE false
@@ -50,6 +51,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DEFAULT_LOG_LEVEL ASD_LogLevel_Warning
 #define DEFAULT_LOG_STREAMS ASD_LogStream_All
 #define DEFAULT_XDP_FAIL_ENABLE true
+#define IDLE_TIMEOUT_ENABLED false
+#define IDLE_TIMEOUT_MS 600000
+#define MINUTESTOMS 60000 //1000*60
+#define HOURSTOMS 3600000 //1000*60*60
+#define MSTOSEC 1000
 
 typedef struct session_options
 {
@@ -67,7 +73,9 @@ typedef struct asd_args
     bool use_syslog;
     ASD_LogLevel log_level;
     ASD_LogStream log_streams;
+    bool log_timestamp_enable;
     bool xdp_fail_enable;
+    timeout_config timeout;
 } asd_args;
 
 typedef struct asd_state
@@ -106,6 +114,10 @@ void deinit_asd_state(asd_state* state);
 STATUS on_client_disconnect(asd_state* state);
 STATUS on_client_connect(asd_state* state, extnet_conn_t* p_extcon);
 void on_connection_aborted(void);
+void send_warning_message(long idle_timeout_ms, long warning_time_ms);
+bool check_idle_timeout(struct timeval* last_activity_time,
+                        bool* send_idle_warning_message,
+                        long idle_timeout_ms, long warning_time_ms);
 STATUS request_processing_loop(asd_state* state);
 STATUS process_new_client(asd_state* state, struct pollfd* poll_fds,
                           size_t num_fds, int* num_clients, int client_index);

--- a/server/config.c
+++ b/server/config.c
@@ -32,9 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "logging.h"
 
-STATUS set_config_defaults(config* config, const bus_options* opt)
+STATUS set_config_defaults(config* config, const bus_options* opt, const timeout_config* tmo_cfg)
 {
-    if (config == NULL || opt == NULL)
+    if (config == NULL || opt == NULL || tmo_cfg== NULL)
     {
         return ST_ERR;
     }
@@ -46,7 +46,8 @@ STATUS set_config_defaults(config* config, const bus_options* opt)
     config->buscfg.enable_i3c = opt->enable_i3c;
     config->buscfg.enable_spp = opt->enable_spp;
     config->buscfg.default_bus = opt->bus;
-
+    config->timecfg.is_timeout_enabled=tmo_cfg->is_timeout_enabled;
+    config->timecfg.idle_timeout=tmo_cfg->idle_timeout;
     for (int i = 0; i < MAX_IxC_BUSES + MAX_SPP_BUSES; i++)
     {
         if (opt->enable_i2c || opt->enable_i3c || opt->enable_spp)

--- a/target/asd_msg.h
+++ b/target/asd_msg.h
@@ -118,6 +118,8 @@ typedef enum
     ScanType_ReadWrite
 } ScanType;
 
+extern int asd_poll_timeout_ms;
+
 STATUS asd_msg_init(config* asd_cfg);
 STATUS asd_msg_free(void);
 STATUS asd_msg_on_msg_recv(void);

--- a/target/dbus_helper.c
+++ b/target/dbus_helper.c
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <safe_str_lib.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "logging.h"
 

--- a/target/i2c_handler.c
+++ b/target/i2c_handler.c
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/file.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <linux/i2c-dev.h>

--- a/target/i3c_debug_handler.h
+++ b/target/i3c_debug_handler.h
@@ -52,7 +52,7 @@ struct i3c_debug_opcode_ccc {
 struct i3c_debug_action_ccc {
     __u8 action;
 };
-#define TIMEOUT_I3C_DEBUG_RX  300   // milliseconds
+#define TIMEOUT_I3C_DEBUG_RX  50   // milliseconds
 
 #define I3C_DEBUG_IOCTL_BASE    0x79
 
@@ -98,7 +98,8 @@ ssize_t receive_i3c(SPP_Handler* state, i3c_cmd *cmd);
 void debug_i3c_rx(i3c_cmd*, int device_index);
 void debug_i3c_tx(i3c_cmd* cmd, int device_index);
 STATUS send_i3c_cmd(SPP_Handler* state, i3c_cmd *cmd);
-STATUS i3c_ibi_handler(int fd, uint8_t* ibi_buffer, size_t* ibi_len);
+STATUS i3c_ibi_handler(int fd, uint8_t* ibi_buffer, size_t* ibi_len,
+                       int device_index);
 
 
 #endif // I3C_DEBUG_HANDLER_H

--- a/target/i3c_handler.c
+++ b/target/i3c_handler.c
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <sys/file.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 // Include local copy of unofficial i3cdev header
@@ -354,7 +355,7 @@ STATUS i3c_read_write(I3C_Handler* state, void* msg_set)
     for (int i = 0; i < ioctl_data->nmsgs; i++)
     {
         xfers[i].len = ioctl_data->msgs[i].len;
-        xfers[i].data = ioctl_data->msgs[i].buf;
+        xfers[i].data = (__u64)ioctl_data->msgs[i].buf;
         xfers[i].rnw = (ioctl_data->msgs[i].flags & I2C_M_RD) ? 1 : 0;
         if (handle == UNINITIALIZED_I3C_DRIVER_HANDLE)
         {
@@ -366,7 +367,7 @@ STATUS i3c_read_write(I3C_Handler* state, void* msg_set)
                         "I3C_RDWR ioctl addr 0x%x handle %d len %d rnw %d",
                         addr, handle, xfers[i].len, xfers[i].rnw);
                 ASD_log_buffer(ASD_LogLevel_Debug, stream, option,
-                               xfers[i].data, xfers[i].len, "I3cBuf");
+                               (const unsigned char *)xfers[i].data, xfers[i].len, "I3cBuf");
             }
             else
             {

--- a/target/spp_handler.h
+++ b/target/spp_handler.h
@@ -35,7 +35,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 
 #define UNINITIALIZED_SPP_DEBUG_DRIVER_HANDLE -1
+/*the i3c-3 might change in future platforms and will need to get updated.*/
+#define BROADCASTACTIONFILE "/sys/bus/i3c/devices/i3c-3/dbgaction_broadcast"
 #define SPASENCLEAR_CMD {0x52, 0x30, 0x04, 0x00, 0xcc, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff}
+#define CLEAR_ERROR_ACTION 0xfd
+#define SPP_IBI_DATA_READY 0xAD
+#define SPP_IBI_STATUS_CHANGED 0x5C
+#define SPP_IBI_SUBREASON_PRDY 0x83
+#define SPP_IBI_SUBREASON_OVERFLOW 0xFF
+#define SPP_IBI_PRDY_WAIT_TIMEOUT_MS 10
+
 typedef uint16_t __u16;
 typedef uint8_t __u8;
 typedef uint32_t __u32;
@@ -75,8 +84,10 @@ STATUS spp_send(SPP_Handler* state, uint16_t size, uint8_t * write_buffer);
 STATUS spp_receive(SPP_Handler* state, uint16_t * size, uint8_t * read_buffer);
 STATUS spp_send_cmd(SPP_Handler* state, spp_command_t cmd, uint16_t size, 
                     uint8_t * write_buffer);
+STATUS send_reset_rx(SPP_Handler* state);
 STATUS spp_send_receive_cmd(SPP_Handler* state, spp_command_t cmd,
                             uint16_t wsize, uint8_t * write_buffer,
                             const uint16_t * rsize, uint8_t * read_buffer);
 STATUS spp_set_sim_data_cmd(SPP_Handler* state, uint16_t size, uint8_t * read_buffer);
+bool check_spp_prdy_event(ASD_EVENT event, ASD_EVENT_DATA event_data);
 #endif // _SPP_HANDLER_H_

--- a/target/target_handler.h
+++ b/target/target_handler.h
@@ -124,11 +124,13 @@ static const Target_Control_GPIOS ASD_PIN_TO_GPIO[] = {
     BMC_TCK_MUX_SEL, // PIN_TCK_MUX_SELECT
 };
 
-typedef STATUS (*TargetReadFunctionPtr)(struct Target_Control_Handle * state,
+typedef struct Target_Control_Handle Target_Control_Handle;
+
+typedef STATUS (*TargetReadFunctionPtr)(Target_Control_Handle* state,
                                         int pin, int * value);
-typedef STATUS (*TargetWriteFunctionPtr)(struct Target_Control_Handle * state,
+typedef STATUS (*TargetWriteFunctionPtr)(Target_Control_Handle* state,
                                          int pin, int value);
-typedef STATUS (*TargetEventFunctionPtr)(struct Target_Control_Handle * state,
+typedef STATUS (*TargetEventFunctionPtr)(Target_Control_Handle* state,
                                          ASD_EVENT*);
 
 #define ALL_PIN_TYPES(FUNC)                                                    \
@@ -160,15 +162,7 @@ typedef struct Target_Control_GPIO
     Pin_Type type;
 } Target_Control_GPIO;
 
-typedef struct ASD_EVENT_DATA
-{
-    uint32_t addr;
-    size_t size;
-    char* buffer;
-} ASD_EVENT_DATA;
-
-
-typedef struct Target_Control_Handle
+struct Target_Control_Handle
 {
     event_configuration event_cfg;
     bool initialized;
@@ -178,7 +172,7 @@ typedef struct Target_Control_Handle
     bool xdp_present;
     int spp_fd;
     SPP_Handler* spp_handler;
-} Target_Control_Handle;
+};
 
 typedef struct data_json_map
 {


### PR DESCRIPTION
ASD Server
- Change: Update version to 1.6.2.
- Feature: Added an option to add timestamps to ASD logs.
- Feature: Added automatic ASD Server disconnection in idle state after timeout.
- Feature: Process All platforms Events Before Processing Client Messages.
- Bug: Fixed build errors with GCC 14.
- Bug: Permit ASD accept connection after XDP presence failure.

ASD Server JTAG
- Feature: Support for Aspeed Jtag driver in HW2 mode
- Bug: Initialize Padding Field in JTAG Shift Operations.
- Bug: Fixed issue found in jtag_test find_pattern function.

Important:
If Intel ASD application base code is updated to version >= 1.5.3 then you must also update JTAG driver code with the version in OpenBMC* Linux* kernel dev-6.1.
Recently Intel added a functionality on the JTAG driver to support RunTCK command. To support this new JTAG driver Intel ASD application has been provided with some compatibility changes that are not backward compatible with previous JTAG driver versions and make Intel ASD fail with a failed to initialize JTAG driver symptom.

ASD Server SPP (Debug over I3C)
- Feature: SPP Auto command support (Performance improvement).
- Feature: Debug over I3C handler tolerance support for configurations without SPP enabled
- Feature: IBI support for multiple devices.
- Feature: Consolidate I3C/BPK Event Handling in Target Handler
- Bug: Fixed issue found in spp_test find_pattern function.

Important:
This release introduces the Auto Command feature for the i3c-debug (SPP) interface, significantly speeding up transactions. With Auto Command, the OpenBMC ASD Server application can automatically handle certain operations and retrieve data without plugin intervention, resulting in faster and more efficient i3c debug performance. Due this feature, the ASD Server 1.6.2 debug over i3c configuration is only compatible with Plugin 1.6.2 which also includes support for the Auto Command feature.

Unresolved Issues: None at this time.